### PR TITLE
Msys2 build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -46,6 +46,12 @@ else ( )
 	set( DBG_SUFFIX )
 endif ( )
 
+if ( BUILD_SHARED )
+	set( TRGT_TYPE Shared )
+else ( )
+	set( TRGT_TYPE Static )
+endif ( )
+
 set( TRGT ${PROJECT_NAME}${DBG_SUFFIX} )
 
 include( "${CMAKE_SOURCE_DIR}/cmake/build_manifest.cmake" )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -40,16 +40,24 @@ if( MSYS )
 	set( LIBS "-lws2_32 -lwsock32" )
 endif()
 
+if ( CMAKE_BUILD_TYPE MATCHES Debug )
+	set( DBG_SUFFIX _d )
+else ( )
+	set( DBG_SUFFIX )
+endif ( )
+
+set( TRGT ${PROJECT_NAME}${DBG_SUFFIX} )
+
 include( "${CMAKE_SOURCE_DIR}/cmake/build_manifest.cmake" )
 
 include_directories( ${INCLUDE_DIR} )
 
-add_library( ${PROJECT_NAME} ${BUILD_MANIFEST} )
+add_library( ${TRGT} ${BUILD_MANIFEST} )
 
 if ( BUILD_SSL )
-    target_link_libraries( ${PROJECT_NAME} LINK_PRIVATE ${ssl_LIBRARY} ${crypto_LIBRARY} ${LIBS} )
+    target_link_libraries( ${TRGT} LINK_PRIVATE ${ssl_LIBRARY} ${crypto_LIBRARY} ${LIBS} )
 else ( )
-    target_link_libraries( ${PROJECT_NAME} ${LIBS} )
+    target_link_libraries( ${TRGT} ${LIBS} )
 endif ( )
 
 if ( BUILD_EXAMPLES )
@@ -75,6 +83,6 @@ include( "${CMAKE_SOURCE_DIR}/cmake/build_artifacts.cmake" )
 
 install( FILES "${INCLUDE_DIR}/${PROJECT_NAME}" DESTINATION "include" )
 install( FILES ${BUILD_ARTIFACTS} DESTINATION "include/corvusoft/${PROJECT_NAME}" )
-install( TARGETS ${PROJECT_NAME}
+install( TARGETS ${TRGT}
          LIBRARY DESTINATION "library"
          ARCHIVE DESTINATION "library" COMPONENT library )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -35,6 +35,11 @@ endif ( )
 #
 # Build
 #
+
+if( MSYS )
+	set( LIBS "-lws2_32 -lwsock32" )
+endif()
+
 include( "${CMAKE_SOURCE_DIR}/cmake/build_manifest.cmake" )
 
 include_directories( ${INCLUDE_DIR} )
@@ -42,9 +47,9 @@ include_directories( ${INCLUDE_DIR} )
 add_library( ${PROJECT_NAME} ${BUILD_MANIFEST} )
 
 if ( BUILD_SSL )
-    target_link_libraries( ${PROJECT_NAME} LINK_PRIVATE ${ssl_LIBRARY} ${crypto_LIBRARY} )
+    target_link_libraries( ${PROJECT_NAME} LINK_PRIVATE ${ssl_LIBRARY} ${crypto_LIBRARY} ${LIBS} )
 else ( )
-    target_link_libraries( ${PROJECT_NAME} )
+    target_link_libraries( ${PROJECT_NAME} ${LIBS} )
 endif ( )
 
 if ( BUILD_EXAMPLES )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -83,6 +83,7 @@ include( "${CMAKE_SOURCE_DIR}/cmake/build_artifacts.cmake" )
 
 install( FILES "${INCLUDE_DIR}/${PROJECT_NAME}" DESTINATION "include" )
 install( FILES ${BUILD_ARTIFACTS} DESTINATION "include/corvusoft/${PROJECT_NAME}" )
-install( TARGETS ${TRGT}
+install (TARGETS ${TRGT}
+         ARCHIVE DESTINATION "library"
          LIBRARY DESTINATION "library"
-         ARCHIVE DESTINATION "library" COMPONENT library )
+         RUNTIME DESTINATION "bin")

--- a/cmake/build_configuration.cmake
+++ b/cmake/build_configuration.cmake
@@ -51,6 +51,16 @@ if( NOT WIN32 )
     endif ( )
 endif ( )
 
+if( MSYS )
+    if ( CMAKE_BUILD_TYPE MATCHES Debug )
+        set( CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DWIN32 -D_WIN32_WINNT=0x0601 -std=c++11 -g -O0 -Wall -Wextra -Weffc++ -pedantic -Wno-unknown-pragmas" )
+    else ( )
+        string( REPLACE "-O3" "" CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE}" )
+        set( CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DWIN32 -D_WIN32_WINNT=0x0601 -std=c++11 -O2 -Wall -Wextra -Weffc++ -pedantic -Wno-unknown-pragmas" )
+    endif ( )
+
+endif ( )
+
 if ( UNIX AND NOT APPLE )
     set( CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -pthread" )
 endif ( )

--- a/example/CMakeLists.txt
+++ b/example/CMakeLists.txt
@@ -7,7 +7,7 @@ cmake_minimum_required( VERSION 2.8.10 )
 #
 # Configuration
 #
-set( EXECUTABLE_OUTPUT_PATH "${CMAKE_CURRENT_BINARY_DIR}/example/${CMAKE_BUILD_TYPE}" )
+set( EXECUTABLE_OUTPUT_PATH "${CMAKE_CURRENT_BINARY_DIR}/example/${TRGT_TYPE}/${CMAKE_BUILD_TYPE}" )
 
 #
 # Build

--- a/example/CMakeLists.txt
+++ b/example/CMakeLists.txt
@@ -7,108 +7,108 @@ cmake_minimum_required( VERSION 2.8.10 )
 #
 # Configuration
 #
-set( EXECUTABLE_OUTPUT_PATH "${CMAKE_CURRENT_BINARY_DIR}/example" )
+set( EXECUTABLE_OUTPUT_PATH "${CMAKE_CURRENT_BINARY_DIR}/example/${CMAKE_BUILD_TYPE}" )
 
 #
 # Build
 #
 add_executable( basic_authentication basic_authentication/source/example.cpp )
-target_link_libraries( basic_authentication ${CMAKE_PROJECT_NAME} )
+target_link_libraries( basic_authentication ${TRGT} )
 
 add_executable( authentication authentication/source/example.cpp )
-target_link_libraries( authentication ${CMAKE_PROJECT_NAME} )
+target_link_libraries( authentication ${TRGT} )
 
 add_executable( custom_status_codes custom_status_codes/source/example.cpp )
-target_link_libraries( custom_status_codes ${CMAKE_PROJECT_NAME} )
+target_link_libraries( custom_status_codes ${TRGT} )
 
 add_executable( digest_authentication digest_authentication/source/example.cpp )
-target_link_libraries( digest_authentication ${CMAKE_PROJECT_NAME} )
+target_link_libraries( digest_authentication ${TRGT} )
 
 add_executable( error_handling error_handling/source/example.cpp )
-target_link_libraries( error_handling ${CMAKE_PROJECT_NAME} )
+target_link_libraries( error_handling ${TRGT} )
 
 add_executable( logging logging/source/example.cpp )
-target_link_libraries( logging ${CMAKE_PROJECT_NAME} )
+target_link_libraries( logging ${TRGT} )
 
 add_executable( path_parameters path_parameters/source/example.cpp )
-target_link_libraries( path_parameters ${CMAKE_PROJECT_NAME} )
+target_link_libraries( path_parameters ${TRGT} )
 
 add_executable( publishing_resources publishing_resources/source/example.cpp )
-target_link_libraries( publishing_resources ${CMAKE_PROJECT_NAME} )
+target_link_libraries( publishing_resources ${TRGT} )
 
 add_executable( custom_methods custom_methods/source/example.cpp )
-target_link_libraries( custom_methods ${CMAKE_PROJECT_NAME} )
+target_link_libraries( custom_methods ${TRGT} )
 
 add_executable( publishing_multipath_resources publishing_multipath_resources/source/example.cpp )
-target_link_libraries( publishing_multipath_resources ${CMAKE_PROJECT_NAME} )
+target_link_libraries( publishing_multipath_resources ${TRGT} )
 
 add_executable( resource_filtering resource_filtering/source/example.cpp )
-target_link_libraries( resource_filtering ${CMAKE_PROJECT_NAME} )
+target_link_libraries( resource_filtering ${TRGT} )
 
 add_executable( serving_html serving_html/source/example.cpp )
-target_link_libraries( serving_html ${CMAKE_PROJECT_NAME} )
+target_link_libraries( serving_html ${TRGT} )
 
 add_executable( transfer_encoding_request transfer_encoding_request/source/example.cpp )
-target_link_libraries( transfer_encoding_request ${CMAKE_PROJECT_NAME} )
+target_link_libraries( transfer_encoding_request ${TRGT} )
 
 add_executable( transfer_encoding_response transfer_encoding_response/source/example.cpp )
-target_link_libraries( transfer_encoding_response ${CMAKE_PROJECT_NAME} )
+target_link_libraries( transfer_encoding_response ${TRGT} )
 
 add_executable( persistent_connection persistent_connection/source/example.cpp )
-target_link_libraries( persistent_connection ${CMAKE_PROJECT_NAME} )
+target_link_libraries( persistent_connection ${TRGT} )
 
 add_executable( compression compression/source/example.cpp )
-target_link_libraries( compression ${CMAKE_PROJECT_NAME} )
+target_link_libraries( compression ${TRGT} )
 
 add_executable( http_service http_service/source/example.cpp )
-target_link_libraries( http_service ${CMAKE_PROJECT_NAME} )
+target_link_libraries( http_service ${TRGT} )
 
 add_executable( service_ready_handler service_ready_handler/source/example.cpp )
-target_link_libraries( service_ready_handler ${CMAKE_PROJECT_NAME} )
+target_link_libraries( service_ready_handler ${TRGT} )
 
 add_executable( session_data session_data/source/example.cpp )
-target_link_libraries( session_data ${CMAKE_PROJECT_NAME} )
+target_link_libraries( session_data ${TRGT} )
 
 add_executable( rules_engine rules_engine/source/example.cpp )
-target_link_libraries( rules_engine ${CMAKE_PROJECT_NAME} )
+target_link_libraries( rules_engine ${TRGT} )
 
 add_executable( multithreaded_service multithreaded_service/source/example.cpp )
-target_link_libraries( multithreaded_service ${CMAKE_PROJECT_NAME} )
+target_link_libraries( multithreaded_service ${TRGT} )
 
 add_executable( schedule_work_on_service_runloop schedule_work_on_service_runloop/source/example.cpp )
-target_link_libraries( schedule_work_on_service_runloop ${CMAKE_PROJECT_NAME} )
+target_link_libraries( schedule_work_on_service_runloop ${TRGT} )
 
 add_executable( bind_service_address bind_service_address/source/example.cpp )
-target_link_libraries( bind_service_address ${CMAKE_PROJECT_NAME} )
+target_link_libraries( bind_service_address ${TRGT} )
 
 add_executable( session_manager session_manager/source/example.cpp )
-target_link_libraries( session_manager ${CMAKE_PROJECT_NAME} )
+target_link_libraries( session_manager ${TRGT} )
 
 add_executable( http_client http_client/source/example.cpp )
-target_link_libraries( http_client ${CMAKE_PROJECT_NAME} )
+target_link_libraries( http_client ${TRGT} )
 
 add_executable( signal_handling signal_handling/source/example.cpp )
-target_link_libraries( signal_handling ${CMAKE_PROJECT_NAME} )
+target_link_libraries( signal_handling ${TRGT} )
 
 if ( PAM_FOUND )
     add_executable( pam_authentication pam_authentication/source/example.cpp )
-    target_link_libraries( pam_authentication ${CMAKE_PROJECT_NAME} pam )
+    target_link_libraries( pam_authentication ${TRGT} pam )
 endif ( )
 
 if ( SYSLOG_FOUND )
     add_executable( syslog_logging syslog_logging/source/example.cpp )
-    target_link_libraries( syslog_logging ${CMAKE_PROJECT_NAME} )
+    target_link_libraries( syslog_logging ${TRGT} )
 endif ( )
 
 if ( BUILD_SSL )
     add_executable( https_service https_service/source/example.cpp )
-    target_link_libraries( https_service ${CMAKE_PROJECT_NAME} )
+    target_link_libraries( https_service ${TRGT} )
 
     add_executable( https_client_verify_none https_client/source/verify_none.cpp )
-    target_link_libraries( https_client_verify_none ${CMAKE_PROJECT_NAME} )
+    target_link_libraries( https_client_verify_none ${TRGT} )
 
     add_executable( https_client_verify_peer https_client/source/verify_peer.cpp )
-    target_link_libraries( https_client_verify_peer ${CMAKE_PROJECT_NAME} )
+    target_link_libraries( https_client_verify_peer ${TRGT} )
 endif ( )
 
 #


### PR DESCRIPTION
Solved the problem related build in msys2.
Fixed the problem related installation dll file: shared library installation didn't work.
Modified library suffix: "d" on the end of filename (librestbed_d.dll) when CMAKE_BUILD_TYPE=Debug.
Modified examples installation path: "${CMAKE_CURRENT_BINARY_DIR}/example/${TRGT_TYPE}/${CMAKE_BUILD_TYPE}".
We can build library in several variants (shared_debug, shared_release, static_debug, static_release) and install in same folder.

Please test in Linux.
